### PR TITLE
Added mount state check to avoid setState error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,12 +23,17 @@ export default class Transition extends Component {
     this.state = {
       props: props.props
     };
+    this.mounted = true;
   }
 
   componentWillReceiveProps(props) {
     this.timer && this.timer.stop();
     this.interpolator = interpolateObject(this.state.props, props.props);
     this.start();
+  }
+
+  componentWillUnmount = () => {
+    this.mounted = false;
   }
 
   start = () => {
@@ -40,13 +45,17 @@ export default class Transition extends Component {
     const {duration, easing} = this.props;
     const t = elapsed / duration;
     let nextState;
-    if (t > 1) {
-      nextState = this.interpolator(1);
+    if(this.mounted){
+      if (t > 1 ) {
+        nextState = this.interpolator(1);
+        this.timer.stop();
+      } else {
+        nextState = this.interpolator(easeMap[easing](t));
+      }
+      this.setState({props: nextState});
+    }else{
       this.timer.stop();
-    } else {
-      nextState = this.interpolator(easeMap[easing](t));
     }
-    this.setState({props: nextState});
   }
 
   render() {


### PR DESCRIPTION
Hey again, I just recently filed issue #4 on this same topic, but I went ahead and figured out a fix for it. This pull request prevents the transition component from continuing to transition after it has unmounted. This helps avoid the `setState` error that gets thrown whenever the component unmounts mid-transition. Note, the React team generally considers this approach to be a bit of an [anti-pattern](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html), but in this case since we're relying on D3 to handle the interpolation, and this works as an ad-hoc "cancel" function for D3.

In order to test this scenario I created an additional story with a button to mount and unmount the transition component. To accomplish this I augmented the Container component to both accept a render prop function as a child, and to pass a reference to the container's `setState` for updating the state from the children, in the case of the toggle button.

Cheers!