### PR TITLE
Do not attempt to stop a non-existing timer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default class Transition extends Component {
   }
 
   componentWillUnmount = () => {
-    this.timer.stop();
+    this.timer && this.timer.stop();
   };
 
   start = () => {


### PR DESCRIPTION
My transition does not start immediately, so there’s sometimes a case when the component is unmounted, but the timer was not started, resulting in `Cannot read property 'stop' of undefined` error in `componentWillUnmount`.

This fix prevents such errors.